### PR TITLE
Error reporting and analytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     compile 'com.android.support:design:25.3.1'
     compile 'com.android.support:support-vector-drawable:25.3.1'
     compile 'com.google.android.gms:play-services-analytics:11.0.4'
+    compile 'com.rollbar:rollbar-android:0.2.1'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.8.9'
 }

--- a/app/src/main/java/com/njitdev/sa_android/home/HomeActivity.java
+++ b/app/src/main/java/com/njitdev/sa_android/home/HomeActivity.java
@@ -46,6 +46,7 @@ import com.njitdev.sa_android.announcements.AnnouncementsActivity;
 import com.njitdev.sa_android.test.TestActivity;
 import com.njitdev.sa_android.utils.ModelListener;
 import com.njitdev.sa_android.utils.SAGlobal;
+import com.njitdev.sa_android.utils.SAUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,11 +61,8 @@ public class HomeActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_home);
 
-        // Initialize shared request queue
-        SAGlobal.sharedRequestQueue = Volley.newRequestQueue(getApplicationContext());
-
-        // Initialize Google Analytics
-        SAGlobal.getGATracker(this);
+        // App init
+        SAUtils.appInit(getApplicationContext());
 
         // Initialize menu list
         updateMenu();

--- a/app/src/main/java/com/njitdev/sa_android/models/analytics/AnalyticsModels.java
+++ b/app/src/main/java/com/njitdev/sa_android/models/analytics/AnalyticsModels.java
@@ -1,0 +1,60 @@
+/*
+    sa-android
+    Copyright (C) 2017 sa-android authors
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.njitdev.sa_android.models.analytics;
+
+import android.util.Log;
+
+import com.android.volley.Request;
+import com.android.volley.Response;
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.JsonObjectRequest;
+import com.njitdev.sa_android.BuildConfig;
+import com.njitdev.sa_android.utils.SAConfig;
+import com.njitdev.sa_android.utils.SAGlobal;
+import com.njitdev.sa_android.utils.SAUtils;
+
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AnalyticsModels {
+    private static String baseURL = SAConfig.baseURL + "/app/analytics";
+
+    // Submit new post
+    public static void sendStartEvent(String installationID) {
+        // Prepare parameters
+        Map<String, String> map = new HashMap<>();
+        map.put("installation_id", installationID);
+        map.put("school", SAConfig.schoolIdentifier);
+        map.put("client_version", BuildConfig.VERSION_NAME);
+        map.put("device_info", SAUtils.getDeviceModel());
+        JSONObject params = new JSONObject(map);
+
+        // Make request
+        JsonObjectRequest jsonObjectRequest = new JsonObjectRequest(Request.Method.POST, baseURL + "/start", params, new Response.Listener<JSONObject>() {
+            @Override
+            public void onResponse(JSONObject response) {}
+        }, new Response.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError error) {}
+        });
+        SAGlobal.sharedRequestQueue.add(jsonObjectRequest);
+    }
+}

--- a/app/src/main/java/com/njitdev/sa_android/utils/SAConfig.java
+++ b/app/src/main/java/com/njitdev/sa_android/utils/SAConfig.java
@@ -22,4 +22,5 @@ public class SAConfig {
     public static Boolean developmentMode = true;
     public static String baseURL;
     public static String schoolIdentifier = "gdut";
+    public static String rollbarClientID = "b321f22cfeaa4ea4b4b22c1f2d0222e2";
 }

--- a/app/src/main/java/com/njitdev/sa_android/utils/SAConfig.java
+++ b/app/src/main/java/com/njitdev/sa_android/utils/SAConfig.java
@@ -19,6 +19,7 @@
 package com.njitdev.sa_android.utils;
 
 public class SAConfig {
-    public static String baseURL = "https://sa-api-dev.njitdev.com";
+    public static Boolean developmentMode = true;
+    public static String baseURL;
     public static String schoolIdentifier = "gdut";
 }

--- a/app/src/main/java/com/njitdev/sa_android/utils/SAUtils.java
+++ b/app/src/main/java/com/njitdev/sa_android/utils/SAUtils.java
@@ -46,7 +46,7 @@ public class SAUtils {
 
             // Error reporting
             // Reports uncaught exceptions by default
-            Rollbar.init(context, "b321f22cfeaa4ea4b4b22c1f2d0222e2", "production");
+            Rollbar.init(context, SAConfig.rollbarClientID, "production");
         }
 
         // Send start event

--- a/app/src/main/java/com/njitdev/sa_android/utils/SAUtils.java
+++ b/app/src/main/java/com/njitdev/sa_android/utils/SAUtils.java
@@ -20,10 +20,39 @@ package com.njitdev.sa_android.utils;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
+
+import com.android.volley.toolbox.Volley;
+import com.njitdev.sa_android.models.analytics.AnalyticsModels;
+import com.rollbar.android.Rollbar;
 
 import java.util.UUID;
 
 public class SAUtils {
+    // Application initialization
+    public static void appInit(Context context) {
+        // Shared request queue
+        SAGlobal.sharedRequestQueue = Volley.newRequestQueue(context);
+
+        // Google Analytics
+        SAGlobal.getGATracker(context);
+
+        if (SAConfig.developmentMode) {
+            // Development mode
+            SAConfig.baseURL = "https://sa-api-dev.njitdev.com";
+        } else {
+            // Production mode
+            SAConfig.baseURL = "https://sa-api-prd.njitdev.com";
+
+            // Error reporting
+            // Reports uncaught exceptions by default
+            Rollbar.init(context, "b321f22cfeaa4ea4b4b22c1f2d0222e2", "production");
+        }
+
+        // Send start event
+        AnalyticsModels.sendStartEvent(installationID(context));
+    }
+
     // Write a KV pair to local storage
     public static void writeKVStore(Context context, String key, String value) {
         SharedPreferences sp = context.getSharedPreferences("sa-android", Context.MODE_PRIVATE);
@@ -49,5 +78,29 @@ public class SAUtils {
             SAGlobal.installation_id = uuid;
         }
         return SAGlobal.installation_id;
+    }
+
+    // Get device model
+    // https://stackoverflow.com/a/12707479/1690380
+    public static String getDeviceModel() {
+        String manufacturer = Build.MANUFACTURER;
+        String model = Build.MODEL;
+        if (model.startsWith(manufacturer)) {
+            return capitalize(model);
+        } else {
+            return capitalize(manufacturer) + " " + model;
+        }
+    }
+
+    private static String capitalize(String s) {
+        if (s == null || s.length() == 0) {
+            return "";
+        }
+        char first = s.charAt(0);
+        if (Character.isUpperCase(first)) {
+            return s;
+        } else {
+            return Character.toUpperCase(first) + s.substring(1);
+        }
     }
 }


### PR DESCRIPTION
Closes #9 

- Add error reporting based on `Rollbar`

- Flag to switch between `development` and `production` mode in `SAConfig`, to control error reporting (only intended for production) and backend URL:

  ```Java
  public static Boolean developmentMode = true;
  ```

- Send app start event to our own analytics API, example data:

  ```JSON
  {
      "school": "gdut",
      "installation_id": "2bae8786b4af41bfabe3",
      "client_version": "0.0.0",
      "device_info": "Unknown Android SDK built for x86_64",
      "ip_addr": "[removed]",
  }
  ```

Rollbar screenshot:
![screen shot 2017-07-30 at 12 51 37](https://user-images.githubusercontent.com/1742004/28755523-0562cd8c-752b-11e7-88c8-6fdf1ec44d1b.png)
